### PR TITLE
remove usage of NSSelectorFromString to avoid app review problems

### DIFF
--- a/Sources/UIViewController+AnyPromise.m
+++ b/Sources/UIViewController+AnyPromise.m
@@ -56,7 +56,7 @@
     }
 
     if (!promise) {
-        if (![vc respondsToSelector:NSSelectorFromString(@"promise")]) {
+        if (![vc respondsToSelector:@selector(promise)]) {
             id userInfo = @{NSLocalizedDescriptionKey: @"ViewController is not promisable"};
             id err = [NSError errorWithDomain:PMKErrorDomain code:PMKInvalidUsageError userInfo:userInfo];
             return [AnyPromise promiseWithValue:err];

--- a/Sources/UIViewController+AnyPromise.m
+++ b/Sources/UIViewController+AnyPromise.m
@@ -13,7 +13,9 @@
 + (instancetype)delegateWithPromise:(AnyPromise **)promise;
 @end
 
-
+@interface UIViewController ()
+- (AnyPromise*) promise;
+@end
 
 @implementation UIViewController (PromiseKit)
 

--- a/Tests/TestUIViewController.swift
+++ b/Tests/TestUIViewController.swift
@@ -93,7 +93,7 @@ private class MockViewController: UIViewController, Promisable {
 
     var appeared = false
 
-    private override func viewDidAppear(_ animated: Bool) {
+    fileprivate override func viewDidAppear(_ animated: Bool) {
         appeared = true
     }
 }


### PR DESCRIPTION
According to some reports (such as [this issue](https://github.com/nicklockwood/GZIP/issues/24)), Apple has gotten overly aggressive with dynamic run-time code resolution, including `respondsToSelector:`.

This pull requests removes the usage of a string for resolving the selector and implements it more directly.