### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,3 @@
 github "mxcl/PromiseKit" ~> 6.0
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKUIKit.xcodeproj/project.pbxproj
+++ b/PMKUIKit.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		63C9C4581D5D339B00101ECE /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 630B2DF51D5D0AD400DC10E9 /* Default-568h@2x.png */; };
 		63C9C45E1D5D341600101ECE /* PMKUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C7FFA71D5BEE09003BAE60 /* PMKUIKit.framework */; };
 		63C9C45F1D5D341600101ECE /* PMKUIKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63C7FFA71D5BEE09003BAE60 /* PMKUIKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		911E6FC620F571F7006F49B9 /* TestUIViewPropertyAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911E6FC520F571F7006F49B9 /* TestUIViewPropertyAnimator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		63C9C4451D5D334700101ECE /* PMKTestsHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PMKTestsHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63CCF8121D5C0C4E00503216 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		63CCF8171D5C11B500503216 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		911E6FC520F571F7006F49B9 /* TestUIViewPropertyAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIViewPropertyAnimator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 				637E2C8E1D5C2E720043E370 /* TestUIImagePickerController.swift */,
 				637E2C8F1D5C2E720043E370 /* TestUIViewController.m */,
 				6332142A1D83CD17009F67CE /* TestUIView.swift */,
+				911E6FC520F571F7006F49B9 /* TestUIViewPropertyAnimator.swift */,
 				637E2C9A1D5C2F600043E370 /* infrastructure.swift */,
 			);
 			path = Tests;
@@ -402,6 +405,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				911E6FC620F571F7006F49B9 /* TestUIViewPropertyAnimator.swift in Sources */,
 				637E2C951D5C2E720043E370 /* TestUIImagePickerController.swift in Sources */,
 				637E2C961D5C2E720043E370 /* TestUIViewController.m in Sources */,
 				637E2C9B1D5C2F600043E370 /* infrastructure.swift in Sources */,

--- a/PMKUIKit.xcodeproj/project.pbxproj
+++ b/PMKUIKit.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 			);
 			inputPaths = (
 				PromiseKit,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (
@@ -370,6 +371,7 @@
 			);
 			inputPaths = (
 				PromiseKit,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Sources/UIViewPropertyAnimator+Promise.swift
+++ b/Sources/UIViewPropertyAnimator+Promise.swift
@@ -1,4 +1,5 @@
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 import UIKit
@@ -8,6 +9,26 @@ public extension UIViewPropertyAnimator {
     func startAnimation(_: PMKNamespacer) -> Guarantee<UIViewAnimatingPosition> {
         return Guarantee {
             addCompletion($0)
+            startAnimation()
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+@available(iOS 10, tvOS 10, *)
+extension UIViewPropertyAnimator: CancellableTask {
+    public func cancel() {
+        stopAnimation(true)
+    }
+    
+    public var isCancelled: Bool {
+        return (state == .inactive) && (fractionComplete < 1.0)
+    }
+    
+    public func startAnimationCC(_: PMKNamespacer) -> CancellablePromise<UIViewAnimatingPosition> {
+        return CancellablePromise(task: self) {
+            addCompletion($0.fulfill)
             startAnimation()
         }
     }

--- a/Tests/TestUIViewPropertyAnimator.swift
+++ b/Tests/TestUIViewPropertyAnimator.swift
@@ -1,0 +1,47 @@
+import PromiseKit
+import PMKCancel
+import PMKUIKit
+import XCTest
+import UIKit
+
+@available(iOS 10, tvOS 10, *)
+class UIViewPropertyAnimatorTests: XCTestCase {
+    func test() {
+        let ex1 = expectation(description: "")
+        let ex2 = expectation(description: "")
+
+        let animator = UIViewPropertyAnimator(duration: 0.1, curve: .easeIn, animations: { [weak self] in
+            ex1.fulfill()
+        })
+        animator.startAnimation(.promise).done { _ in
+            ex2.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+@available(iOS 10, tvOS 10, *)
+extension UIViewPropertyAnimatorTests {
+    func testCancel() {
+        let ex1 = expectation(description: "")
+        let ex2 = expectation(description: "")
+        
+        let animator = UIViewPropertyAnimator(duration: 0.1, curve: .easeIn, animations: { [weak self] in
+            ex1.fulfill()
+        })
+        let p = animator.startAnimationCC(.promise).done { _ in
+            XCTFail()
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex2.fulfill() : XCTFail("Error: \(error)")
+        }
+        p.cancel()
+        
+        XCTAssert(animator.isCancelled)
+        XCTAssert(p.isCancelled)
+
+        waitForExpectations(timeout: 1)
+    }
+}


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
